### PR TITLE
adds emitPerDoc option

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -12,6 +12,7 @@ module.exports = {
   buildSchedule: function(details) {
     var storage = _.extend({}, _.pick(details, 'collection', 'id'))
     var conditions = _.extend({}, _.pick(details, 'query', 'after'))
+    var options = _.defaults(details.options || {}, {emitPerDoc: false})
 
     var doc = {
       status: details.status || 'ready',
@@ -19,6 +20,7 @@ module.exports = {
       storage: storage,
       conditions: conditions,
       data: details.data,
+      options: options
     }
 
     var query = {

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -57,7 +57,7 @@ function Scheduler(connection, opts) {
       $or: [
         {'conditions.after': {'$exists': 0}},
         {'conditions.after': {'$lte': new Date()}}
-      ],
+      ]
     }
 
     db.command({
@@ -76,12 +76,19 @@ function Scheduler(connection, opts) {
         if(err) return self.emit('error', err, event)
         coll.find(event.conditions.query, function(err, cursor) {
           if (err) return self.emit('error', err, event)
-          cursor.each(function(err, doc) {
-            if (err) return self.emit('error', err, event)
-            if (!doc) return poll();
+          if(event.options.emitPerDoc || !!event.storage.id)
+            cursor.each(function(err, doc) {
+              if (err) return self.emit('error', err, event)
+              if (!doc) return poll();
 
-            emit(event, doc)
-          })
+              emit(event, doc)
+            })
+          else
+            cursor.toArray(function(err, results) {
+              if (err) return self.emit('error', err, event)
+              if (results.length === 0) return poll();
+              emit(event, results)
+            })
         })
       })
     })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mongo-scheduler",
   "description": "persistent event scheduler using mongo as storage",
-  "version": "0.4.3",
+  "version": "1.0.0",
   "keywords": [
     "job",
     "jobs",
@@ -24,7 +24,7 @@
   "devDependencies": {
     "mocha": "~1.13.0",
     "moment": "2.10.3",
-    "should": "~2.0.1",
+    "should": "7.0.1",
     "sinon": "~1.8.1"
   },
   "scripts": {

--- a/test/helper.test.js
+++ b/test/helper.test.js
@@ -16,12 +16,13 @@ describe('schedule builder', function() {
 
   it('should return doc to insert', function() {
     var doc = helper.buildSchedule(this.details).doc
-    doc.should.eql({
+    doc.should.have.properties({
       event: 'name',
       status: 'ready',
       conditions: { query: 'query', after: 'date' },
       storage: { collection: 'collection', id: 'recordId' },
-      data: { my: 'data' }
+      data: { my: 'data' },
+      options: {emitPerDoc: false}
     })
   })
 

--- a/test/scheduler.test.js
+++ b/test/scheduler.test.js
@@ -225,8 +225,6 @@ describe('emitter', function() {
     it("emits an event with multiple records", function(done) {
       var running = true
       this.scheduler.on('awesome', function(docs) {
-        console.log("hello")
-        console.dir(docs)
         docs.length.should.eql(2)
         if(running) done()
         running = false

--- a/test/scheduler.test.js
+++ b/test/scheduler.test.js
@@ -109,7 +109,7 @@ describe('emitter', function() {
   it('should emit an event with matching records', function(done) {
     var running = true
     this.scheduler.on('awesome', function(doc) {
-      doc.message.should.eql('This is a record')
+      doc[0].message.should.eql('This is a record')
       if(running) done()
       running = false
     })
@@ -117,6 +117,24 @@ describe('emitter', function() {
     this.records.insert({message: 'This is a record'}, function() {
       this.scheduler.schedule(details)
     }.bind(this))
+  })
+
+  it("emits an event with multiple records", function(done) {
+    var running = true
+    this.scheduler.on('awesome', function(docs) {
+      docs.length.should.eql(2)
+      if(running) done()
+      running = false
+    })
+
+    this.records.insert([
+      {message: 'This is a record'},
+      {message: 'Another Record'}
+    ], function() {
+      this.scheduler.schedule(details)
+    }.bind(this))
+
+    done()
   })
 
   it('emits the original event', function(done) {
@@ -165,6 +183,62 @@ describe('emitter', function() {
     })
 
     this.scheduler.schedule({name: 'empty'})
+  })
+
+  describe("with emitPerDoc", function() {
+    var additionalDetails = _.extend({
+      options: {emitPerDoc: true}
+    }, details)
+
+    it('should emit an event per doc', function(done) {
+      var running = true
+      this.scheduler.on('awesome', function(doc) {
+        doc.message.should.eql('This is a record')
+        if(running) done()
+        running = false
+      })
+      this.records.insert([
+        {message: 'This is a record'},
+        {message: 'This is a record'}
+      ], function() {
+        this.scheduler.schedule(additionalDetails)
+      }.bind(this))
+    })
+  })
+
+  describe("with a query", function() {
+    var additionalDetails = _.extend({query: {}}, details)
+
+    it('should emit an event with matching records', function(done) {
+      var running = true
+      this.scheduler.on('awesome', function(docs) {
+        docs[0].message.should.eql('This is a record')
+        if(running) done()
+        running = false
+      })
+
+      this.records.insert({message: 'This is a record'}, function() {
+        this.scheduler.schedule(additionalDetails)
+      }.bind(this))
+    })
+
+    it("emits an event with multiple records", function(done) {
+      var running = true
+      this.scheduler.on('awesome', function(docs) {
+        console.log("hello")
+        console.dir(docs)
+        docs.length.should.eql(2)
+        if(running) done()
+        running = false
+      })
+
+      this.records.insert([
+        {message: 'This is a record'},
+        {message: 'Another Record'}
+      ], function() {
+        this.scheduler.schedule(additionalDetails)
+      }.bind(this))
+    })
   })
 
   describe('with cron string', function() {


### PR DESCRIPTION
This option makes it so that an event will include all records
that result from a query by default. To fire 1 event for each
individual record, set options.emitPerDoc = true